### PR TITLE
Dev fixes

### DIFF
--- a/cancer_ai/chain_models_store.py
+++ b/cancer_ai/chain_models_store.py
@@ -31,7 +31,7 @@ class ChainMinerModel(BaseModel):
     def from_compressed_str(cls, cs: str) -> Type["ChainMinerModel"]:
         """Returns an instance of this class from a compressed string representation"""
         tokens = cs.split(":")
-        if len(tokens) != 6:
+        if len(tokens) != 5:
             return None
         return cls(
             hf_repo_id=tokens[0],

--- a/cancer_ai/chain_models_store.py
+++ b/cancer_ai/chain_models_store.py
@@ -20,16 +20,12 @@ class ChainMinerModel(BaseModel):
     block: Optional[int] = Field(
         description="Block on which this model was claimed on the chain."
     )
-    hotkey: Optional[str] = Field(
-        description="Hotkey of the model owner"
-    )
-
     class Config:
         arbitrary_types_allowed = True
 
     def to_compressed_str(self) -> str:
         """Returns a compressed string representation."""
-        return f"{self.hf_repo_id}:{self.hf_model_filename}:{self.hf_code_filename}:{self.competition_id}:{self.hf_repo_type}:{self.hotkey}"
+        return f"{self.hf_repo_id}:{self.hf_model_filename}:{self.hf_code_filename}:{self.competition_id}:{self.hf_repo_type}"
 
     @classmethod
     def from_compressed_str(cls, cs: str) -> Type["ChainMinerModel"]:
@@ -43,7 +39,6 @@ class ChainMinerModel(BaseModel):
             hf_code_filename=tokens[2],
             competition_id=tokens[3],
             hf_repo_type=tokens[4],
-            hotkey=tokens[5],
             block=None,
         )
 

--- a/cancer_ai/validator/competition_manager.py
+++ b/cancer_ai/validator/competition_manager.py
@@ -131,7 +131,7 @@ class CompetitionManager(SerializableManager):
 
     async def chain_miner_to_model_info(
         self, chain_miner_model: ChainMinerModel
-    ) -> ModelInfo | None:
+    ) -> ModelInfo:
         bt.logging.warning(f"Chain miner model: {chain_miner_model.model_dump()}")
         if chain_miner_model.competition_id != self.competition_id:
             bt.logging.debug(
@@ -166,6 +166,7 @@ class CompetitionManager(SerializableManager):
                 bt.logging.warning(
                     f"Miner {model.hotkey} does not belong to this competition, skipping"
                 )
+                continue
             self.model_manager.hotkey_store[model.hotkey] = model_info
         bt.logging.info(
             f"Amount of hotkeys with valid models: {len(self.model_manager.hotkey_store)}"

--- a/cancer_ai/validator/competition_manager.py
+++ b/cancer_ai/validator/competition_manager.py
@@ -159,7 +159,7 @@ class CompetitionManager(SerializableManager):
         bt.logging.info(f"Amount of hotkeys: {len(self.hotkeys)}")
 
         latest_models = self.db_controller.get_latest_models(self.hotkeys)
-        for hotkey, model in latest_models:
+        for hotkey, model in latest_models.items():
             try:
                 model_info = await self.chain_miner_to_model_info(model)
             except ValueError:

--- a/cancer_ai/validator/competition_manager.py
+++ b/cancer_ai/validator/competition_manager.py
@@ -159,15 +159,16 @@ class CompetitionManager(SerializableManager):
         bt.logging.info(f"Amount of hotkeys: {len(self.hotkeys)}")
 
         latest_models = self.db_controller.get_latest_models(self.hotkeys)
-        for model in latest_models:
+        for latest_model in latest_models:
+            model, hotkey = latest_model
             try:
                 model_info = await self.chain_miner_to_model_info(model)
             except ValueError:
                 bt.logging.warning(
-                    f"Miner {model.hotkey} does not belong to this competition, skipping"
+                    f"Miner {hotkey} does not belong to this competition, skipping"
                 )
                 continue
-            self.model_manager.hotkey_store[model.hotkey] = model_info
+            self.model_manager.hotkey_store[hotkey] = model_info
         bt.logging.info(
             f"Amount of hotkeys with valid models: {len(self.model_manager.hotkey_store)}"
         )

--- a/cancer_ai/validator/competition_manager.py
+++ b/cancer_ai/validator/competition_manager.py
@@ -159,8 +159,7 @@ class CompetitionManager(SerializableManager):
         bt.logging.info(f"Amount of hotkeys: {len(self.hotkeys)}")
 
         latest_models = self.db_controller.get_latest_models(self.hotkeys)
-        for latest_model in latest_models:
-            model, hotkey = latest_model
+        for hotkey, model in latest_models:
             try:
                 model_info = await self.chain_miner_to_model_info(model)
             except ValueError:

--- a/cancer_ai/validator/model_db.py
+++ b/cancer_ai/validator/model_db.py
@@ -119,7 +119,7 @@ class ModelDBController:
             bt.logging.error(f"Error retrieving block timestamp: {e}")
             raise
 
-    def get_latest_models(self, hotkeys: list[str], cutoff_time: float = None) -> list[ChainMinerModel]:
+    def get_latest_models(self, hotkeys: list[str], cutoff_time: float = None) -> list[tuple[ChainMinerModel, str]]:
         cutoff_time = datetime.now() - timedelta(minutes=cutoff_time) if cutoff_time else datetime.now()
         session = self.Session()
         try:
@@ -135,7 +135,8 @@ class ModelDBController:
                 )
                 if model_record:
                     latest_models.append(
-                        self.convert_db_model_to_chain_model(model_record)
+                        self.convert_db_model_to_chain_model(model_record),
+                        hotkey,
                     )
 
             return latest_models

--- a/cancer_ai/validator/model_db.py
+++ b/cancer_ai/validator/model_db.py
@@ -119,12 +119,12 @@ class ModelDBController:
             bt.logging.error(f"Error retrieving block timestamp: {e}")
             raise
 
-    def get_latest_models(self, hotkeys: list[str], cutoff_time: float = None) -> list[tuple[ChainMinerModel, str]]:
+    def get_latest_models(self, hotkeys: list[str], cutoff_time: float = None) -> dict[str, ChainMinerModel]:
         cutoff_time = datetime.now() - timedelta(minutes=cutoff_time) if cutoff_time else datetime.now()
         session = self.Session()
         try:
             # Use a correlated subquery to get the latest record for each hotkey that doesn't violate the cutoff
-            latest_models = []
+            latest_models_to_hotkeys = {}
             for hotkey in hotkeys:
                 model_record = (
                     session.query(ChainMinerModelDB)
@@ -134,11 +134,9 @@ class ModelDBController:
                     .first()  # Get the first (newest) record that meets the cutoff condition
                 )
                 if model_record:
-                    latest_models.append(
-                        (self.convert_db_model_to_chain_model(model_record), hotkey)
-                    )
+                    latest_models_to_hotkeys[hotkey] = self.convert_db_model_to_chain_model(model_record)
 
-            return latest_models
+            return latest_models_to_hotkeys
         finally:
             session.close()
 

--- a/cancer_ai/validator/model_db.py
+++ b/cancer_ai/validator/model_db.py
@@ -198,5 +198,4 @@ class ModelDBController:
             hf_repo_type=model_record.hf_repo_type,
             hf_code_filename=model_record.hf_code_filename,
             block=model_record.block,
-            hotkey=model_record.hotkey,
         )

--- a/cancer_ai/validator/model_db.py
+++ b/cancer_ai/validator/model_db.py
@@ -135,8 +135,7 @@ class ModelDBController:
                 )
                 if model_record:
                     latest_models.append(
-                        self.convert_db_model_to_chain_model(model_record),
-                        hotkey,
+                        (self.convert_db_model_to_chain_model(model_record), hotkey)
                     )
 
             return latest_models

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -176,13 +176,12 @@ class MinerManagerCLI:
 
         # Push model metadata to chain
         model_id = ChainMinerModel(
-            competition_id=self.config.competition.id,
+            competition_id=self.config.competition_id,
             hf_repo_id=self.config.hf_repo_id,
             hf_model_filename=self.config.hf_model_name,
             hf_repo_type=self.config.hf_repo_type,
             hf_code_filename=self.config.hf_code_filename,
             block=None,
-            hotkey=self.hotkey,
         )
         await self.metadata_store.store_model_metadata(model_id)
         bt.logging.success(

--- a/neurons/tests/competition_runner_test.py
+++ b/neurons/tests/competition_runner_test.py
@@ -14,6 +14,7 @@ from cancer_ai.utils.config import path_config
 from cancer_ai.validator.utils import get_competition_config
 from cancer_ai.mock import MockSubtensor
 from cancer_ai.validator.models import CompetitionsListModel, CompetitionModel
+from cancer_ai.validator.model_db import ModelDBController
 
 
 COMPETITION_FILEPATH = "config/competition_config_testnet.json"
@@ -34,6 +35,7 @@ test_config = SimpleNamespace(
             }
         ),
         "hf_token": "HF_TOKEN",
+        "db_path": "models.db",
     }
 )
 
@@ -55,13 +57,13 @@ async def run_competitions(
             subtensor=subtensor,
             hotkeys=hotkeys,
             validator_hotkey="Walidator",
-            chain_miners_store={},
             competition_id=competition_cfg.competition_id,
             category=competition_cfg.category,
             dataset_hf_repo=competition_cfg.dataset_hf_repo,
             dataset_hf_id=competition_cfg.dataset_hf_filename,
             dataset_hf_repo_type=competition_cfg.dataset_hf_repo_type,
             test_mode=True,
+            db_controller=ModelDBController(subtensor, test_config.db_path)
         )
         results[competition_cfg.competition_id] = await competition_manager.evaluate()
 
@@ -80,13 +82,13 @@ def config_for_scheduler(subtensor: bt.subtensor) -> Dict[str, CompetitionManage
                 subtensor=subtensor,
                 hotkeys=[],
                 validator_hotkey="Walidator",
-                chain_miners_store={},
                 competition_id=competition_cfg.competition_id,
                 category=competition_cfg.category,
                 dataset_hf_repo=competition_cfg.dataset_hf_repo,
                 dataset_hf_id=competition_cfg.dataset_hf_filename,
                 dataset_hf_repo_type=competition_cfg.dataset_hf_repo_type,
                 test_mode=True,
+                db_controller=ModelDBController(subtensor, test_config.db_path)
             )
     return time_arranged_competitions
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -65,7 +65,7 @@ class Validator(BaseValidatorNeuron):
         self.chain_models = ChainModelMetadata(
             self.subtensor, self.config.netuid, self.wallet
         )
-        self.last_miners_refresh: float
+        self.last_miners_refresh: float = None
 
     async def concurrent_forward(self):
         coroutines = [
@@ -134,6 +134,7 @@ class Validator(BaseValidatorNeuron):
             subtensor = self.subtensor,
             hotkeys = self.hotkeys,
             validator_hotkey = self.hotkey,
+            db_controller=self.db_controller,
             test_mode = False,
         )
         try:


### PR DESCRIPTION
One more bug (so far)

```
2024-10-15 01:33:29.499 |      DEBUG       | bittensor:loggingmachine.py:372 |  - Chain miner model eatcats/melanoma-test:2024-08-24_04-37-34-melanoma-1:melanoma-1:2024-08-26 15:46:5H6jVFi19DsXeAmajmuLUnB1Nak2bANjH8XsmjtSwHAqsjWg does not belong to this competition - 
2024-10-15 01:33:29.499 |     WARNING      | bittensor:loggingmachine.py:387 |  - Miner 5H6jVFi19DsXeAmajmuLUnB1Nak2bANjH8XsmjtSwHAqsjWg does not belong to this competition, skipping - 
2024-10-15 01:33:29.500 |      ERROR       | bittensor:loggingmachine.py:392 |  - Error running competition: Traceback (most recent call last):
  File "/Users/wojtasy/dev/_cancer_ai/cancerai/neurons/validator.py", line 142, in competition_loop_tick
    await run_competitions_tick(self.competition_scheduler, self.run_log)
  File "/Users/wojtasy/dev/_cancer_ai/cancerai/neurons/competition_runner.py", line 133, in run_competitions_tick
    await competition_manager.evaluate()
  File "/Users/wojtasy/dev/_cancer_ai/cancerai/cancer_ai/validator/competition_manager.py", line 180, in evaluate
    await self.sync_chain_miners()
  File "/Users/wojtasy/dev/_cancer_ai/cancerai/cancer_ai/validator/competition_manager.py", line 169, in sync_chain_miners
    self.model_manager.hotkey_store[model.hotkey] = model_info
                                                    ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'model_info' where it is not associated with a value
 - 
 ```
 
 command to run :

```
python neurons/validator.py  --wallet.name=validator-staked --wallet.hotkey=default --netuid=163 --logging.debug --subtensor.network test --test_mode --competition.config_path "./config/competition_config_testnet.json"
```