### PR TITLE
linking models HF reference with chain

### DIFF
--- a/cancer_ai/validator/competition_manager.py
+++ b/cancer_ai/validator/competition_manager.py
@@ -75,7 +75,7 @@ class CompetitionManager(SerializableManager):
         self.competition_id = competition_id
         self.results: list[tuple[str, ModelEvaluationResult]] = []
         self.error_results: list[tuple[str, str]] = []
-        self.model_manager = ModelManager(self.config, db_controller, parent=self)
+        self.model_manager = ModelManager(self.config, db_controller, parent=self, subtensor=subtensor)
         self.dataset_manager = DatasetManager(
             config=self.config,
             competition_id=competition_id,

--- a/cancer_ai/validator/competition_manager.py
+++ b/cancer_ai/validator/competition_manager.py
@@ -28,6 +28,7 @@ load_dotenv()
 COMPETITION_HANDLER_MAPPING = {
     "melanoma-1": MelanomaCompetitionHandler,
     "melanoma-testnet": MelanomaCompetitionHandler,
+    "melanoma-testnet2": MelanomaCompetitionHandler,
     "melanoma-7": MelanomaCompetitionHandler,
     "melanoma-2": MelanomaCompetitionHandler,
     "melanoma-3": MelanomaCompetitionHandler,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -154,7 +154,7 @@ class Validator(BaseValidatorNeuron):
             if not winning_hotkey:
                 bt.logging.error("NO WINNING HOTKEY")
         except Exception as e:
-            bt.logging.error(f"Error evaluating {data_package.dataset_hf_filename}: {e}")
+            bt.logging.error(f"Error evaluating {data_package.dataset_hf_filename}: {e}", exc_info=True)
             return
 
         models_results = competition_manager.results


### PR DESCRIPTION
## Problem (Attack Scenario)

There is a vulnerability in the system (e.g., a blockchain-based model registration and evaluation network) where the following attack is possible:

*  An attacker copies a competitive model that is about to be deregistered, but did not win.

* The attacker uploads the same model just before the original is 
* Once the original owner is deregistered, the system compares models only against current metadata, which has been reset — the original data is no longer 
* As a result, the attacker's submission appears unique or original, since historical metadata is not referenced, and the model is no longer linked to its true origin.

## Why This Happens

* The current system relies only on the metadata of active participants (hotkeys).
* When a participant is deregistered, their metadata is removed or reset.
* There is no persistent link between a model and its initial on-chain commitment (submission).

## What This PR Intends to Fix

* Couple each model with the specific commit block/extrinsic on the blockchain:
* This creates a permanent link between the model and its first appearance on chain, even if the participant is later deregistered.
* The model’s origin can be reliably traced and verified independently of current participants.
* Stop relying only on the current state of the network for 

The current implementation checks models against the active participants' metadata, which is reset on deregistration.

The new solution proposes comparing models using data fetched directly from the blockchain's history (extrinsics, commits, hash).

## Benefits of the New Approach

* Prevents model plagiarism attacks where someone tries to take credit after the original is gone.
* Ensures model provenance: models are permanently tied to their first submission.
*  More reliable originality checks, using historical blockchain data instead of ephemeral metadata.

